### PR TITLE
ADB Backup: fix adb restore issues

### DIFF
--- a/adbbu/twadbstream.h
+++ b/adbbu/twadbstream.h
@@ -21,7 +21,7 @@
 #define TW_ADB_BU_CONTROL "/tmp/twadbbucontrol"		//FIFO for sending control from TWRP to ADB Backup
 #define TW_ADB_TWRP_CONTROL "/tmp/twadbtwrpcontrol"	//FIFO for sending control from ADB Backup to TWRP
 #define TWRP "TWRP"					//Magic Value
-#define ADB_BU_MAX_ERROR 10				//Max amount of errors for while loops
+#define ADB_BU_MAX_ERROR 20				//Max amount of errors for while loops
 
 //ADB Backup Control Commands
 #define TWSTREAMHDR "twstreamheader"			//TWRP Parititon Count Control

--- a/adbbu/twrpback.cpp
+++ b/adbbu/twrpback.cpp
@@ -514,7 +514,6 @@ int twrpback::restore(void) {
 				return -1;
 			}
 		}
-
 		//If we should read from the adb stream, write commands and data to TWRP
 		if (read_from_adb) {
 			std::string cmdstr;
@@ -547,6 +546,7 @@ int twrpback::restore(void) {
 							close_restore_fds();
 							return -1;
 						}
+						read_from_adb = false;
 					}
 					else {
 						adblogwrite("ADB TWENDADB crc header doesn't match\n");

--- a/openrecoveryscript.cpp
+++ b/openrecoveryscript.cpp
@@ -903,6 +903,7 @@ int OpenRecoveryScript::Restore_ADB_Backup(void) {
 					part_settings.partition_count = partition_count;
 					part_settings.adbbackup = true;
 					part_settings.adb_compression = twimghdr.compressed;
+					part_settings.Part->Set_Backup_FileName(part_settings.Part->Get_Backup_Name() + "." + part_settings.Part->Current_File_System + ".win");
 					part_settings.total_restore_size += part_settings.Part->Get_Restore_Size(&part_settings);
 					part_settings.PM_Method = PM_RESTORE;
 					ProgressTracking progress(part_settings.total_restore_size);

--- a/partition.cpp
+++ b/partition.cpp
@@ -2947,3 +2947,11 @@ void TWPartition::Revert_Adopted() {
 	LOGINFO("Revert_Adopted: no crypto support\n");
 #endif
 }
+
+void TWPartition::Set_Backup_FileName(string fname) {
+	Backup_FileName = fname;
+}
+
+string TWPartition::Get_Backup_Name() {
+	return Backup_Name;
+}

--- a/partitionmanager.cpp
+++ b/partitionmanager.cpp
@@ -915,6 +915,10 @@ int TWPartitionManager::Run_Backup(bool adbbackup) {
 bool TWPartitionManager::Restore_Partition(PartitionSettings *part_settings) {
 	time_t Start, Stop;
 
+	if (part_settings->adbbackup) {
+		part_settings->Part->Set_Backup_FileName(part_settings->Part->Backup_Name + "." + part_settings->Part->Current_File_System + ".win");
+	}
+
 	TWFunc::SetPerformanceMode(true);
 
 	time(&Start);

--- a/partitions.hpp
+++ b/partitions.hpp
@@ -106,6 +106,8 @@ public:
 	int Decrypt_Adopted();
 	void Revert_Adopted();
 	void Partition_Post_Processing(bool Display_Error);                       // Apply partition specific settings after fstab processed
+	void Set_Backup_FileName(string fname);                                   // Set Backup_FileName for partition
+	string Get_Backup_Name();                                                 // Get Backup_Name for partition
 
 public:
 	string Current_File_System;                                               // Current file system

--- a/twrpTar.cpp
+++ b/twrpTar.cpp
@@ -1463,7 +1463,7 @@ int twrpTar::entryExists(string entry) {
 }
 
 unsigned long long twrpTar::get_size() {
-	if (TWFunc::Path_Exists(tarfn) && !part_settings->adbbackup) {
+	if (part_settings->adbbackup || TWFunc::Path_Exists(tarfn)) {
 		LOGINFO("Single archive\n");
 		return uncompressedSize(tarfn);
 	} else {


### PR DESCRIPTION
Set Backup_FileName on adb backup to fix restore.
Set read_from_adb after EOF to return properly
from newer adb client prompt.
Create setter and getter for Backup_FileName
for openrecoveryscript.cpp which is not a
friend class.
Fix condition for twrpTar::Get_Size() and adb backup.
Change-Id: I7eb8168fa3416366b996e220cecbc0e1bcec5e8e