### PR TITLE
etc: remove "." from LD_LIBRARY_PATH

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -24,7 +24,7 @@ service set_permissive /sbin/permissive.sh
 
 on init
     export PATH /sbin:/system/bin
-    export LD_LIBRARY_PATH .:/sbin
+    export LD_LIBRARY_PATH /sbin
 
     export ANDROID_ROOT /system
     export ANDROID_DATA /data


### PR DESCRIPTION
We shouldn't load libraries from some random working directory.
For example it breaks busybox when you're in /system/lib.

Change-Id: Ia1f8f4fda9e6182c0cd8c5ac727c2b1eb09c84a2