### PR TITLE
Fix various memory errors

### DIFF
--- a/adbbu/twadbstream.h
+++ b/adbbu/twadbstream.h
@@ -65,6 +65,11 @@ struct AdbBackupControlType {
 	char type[16];					//stores the type of command, TWENDADB, TWCNT, TWEOF, TWMD5, TWDATA and TWERROR
 	uint32_t crc;					//stores the zlib 32 bit crc of the AdbBackupControlType struct to allow for making sure we are processing metadata
 	char space[484];				//stores space to align the struct to 512 bytes
+
+	//return a C++ string while not reading outside the type char array
+	std::string get_type() {
+		return std::string(type, strnlen(type, sizeof(type)-1));
+	}
 };
 
 //general info for file metadata stored in adb backup header

--- a/adbbu/twrpback.cpp
+++ b/adbbu/twrpback.cpp
@@ -133,7 +133,12 @@ int twrpback::backup(std::string command) {
 		}
 	}
 
-	sprintf(operation, "adbbackup %s", command.c_str());
+	memset(operation, 0, sizeof(operation));
+	if (snprintf(operation, sizeof(operation), "adbbackup %s", command.c_str()) >= sizeof(operation)) {
+		adblogwrite("Operation too big to write to ORS_INPUT_FILE\n");
+		close_backup_fds();
+		return -1;
+	}
 	if (write(write_fd, operation, sizeof(operation)) != sizeof(operation)) {
 		adblogwrite("Unable to write to ORS_INPUT_FILE\n");
 		close_backup_fds();
@@ -173,8 +178,7 @@ int twrpback::backup(std::string command) {
 			struct AdbBackupControlType structcmd;
 
 			memcpy(&structcmd, cmd, sizeof(cmd));
-			std::string cmdstr(structcmd.type);
-			std::string cmdtype = cmdstr.substr(0, sizeof(structcmd.type) - 1);
+			std::string cmdtype = structcmd.get_type();
 
 			//we received an error, exit and unlink
 			if (cmdtype == TWERROR) {
@@ -396,7 +400,6 @@ int twrpback::backup(std::string command) {
 
 int twrpback::restore(void) {
 	twrpDigest adb_md5;
-	char cmd[MAX_ADB_READ];
 	char result[MAX_ADB_READ];
 	struct AdbBackupControlType structcmd;
 	int adb_control_twrp_fd, errctr = 0;
@@ -436,6 +439,7 @@ int twrpback::restore(void) {
 		}
 	}
 
+	memset(operation, 0, sizeof(operation));
 	sprintf(operation, "adbrestore");
 	if (write(write_fd, operation, sizeof(operation)) != sizeof(operation)) {
 		adblogwrite("Unable to write to ORS_INPUT_FILE\n");
@@ -489,8 +493,7 @@ int twrpback::restore(void) {
 		if (read(adb_control_bu_fd, &cmd, sizeof(cmd)) > 0) {
 			struct AdbBackupControlType structcmd;
 			memcpy(&structcmd, cmd, sizeof(cmd));
-			std::string cmdstr(structcmd.type);
-			std::string cmdtype = cmdstr.substr(0, sizeof(structcmd.type) - 1);
+			std::string cmdtype = structcmd.get_type();
 
 			//If we receive TWEOF from TWRP close adb data fifo
 			if (cmdtype == TWEOF) {
@@ -516,13 +519,11 @@ int twrpback::restore(void) {
 		}
 		//If we should read from the adb stream, write commands and data to TWRP
 		if (read_from_adb) {
-			std::string cmdstr;
 			int readbytes;
 			if ((readbytes = fread(result, 1, sizeof(result), adbd_fp)) == sizeof(result)) {
 				totalbytes += readbytes;
 				memcpy(&structcmd, result, sizeof(result));
-				cmdstr = structcmd.type;
-				std::string cmdtype = cmdstr.substr(0, sizeof(structcmd.type) - 1);
+				std::string cmdtype = structcmd.get_type();
 
 				//Tell TWRP we have read the entire adb stream
 				if (cmdtype == TWENDADB) {
@@ -663,9 +664,9 @@ int twrpback::restore(void) {
 						}
 						totalbytes += readbytes;
 						memcpy(&structcmd, result, sizeof(result));
-						cmdstr = structcmd.type;
+						std::string cmdtype = structcmd.get_type();
 
-						if (cmdstr.substr(0, sizeof(MD5TRAILER) - 1) == MD5TRAILER) {
+						if (cmdtype.substr(0, sizeof(MD5TRAILER) - 1) == MD5TRAILER) {
 							struct AdbBackupFileTrailer md5tr;
 							uint32_t crc, md5trcrc, md5ident, md5identmatch;
 
@@ -775,6 +776,12 @@ int main(int argc, char **argv) {
 		tw.adblogwrite("Unable to create TW_ADB_TWRP_CONTROL fifo: " + str.str() + "\n");
 		unlink(TW_ADB_TWRP_CONTROL);
 		unlink(TW_ADB_BU_CONTROL);
+		return -1;
+	}
+
+	if (argc <= 1) {
+		tw.adblogwrite("No parameters given, exiting...\n");
+		tw.close_restore_fds();
 		return -1;
 	}
 


### PR DESCRIPTION
There were a few memory errors while restoring a backup via adb (created
using `adb backup --twrp`).
On my device (S5 mini) it resulted in this error message:

  FORTIFY: strlen: prevented read past end of buffer

This commit fixes this issue and a few other potential issues.

Change-Id: I5022c94c961217238b3fefec0b2c4b8c6fa26ec7