### PR TITLE
adbbackup: write smaller reads less than 512 bytes

### DIFF
--- a/adbbu/twrpback.cpp
+++ b/adbbu/twrpback.cpp
@@ -330,7 +330,7 @@ int twrpback::backup(std::string command) {
 		//to the adb stream.
 		//If the stream is compressed, we need to always write the data.
 		if (writedata || compressed) {
-			while ((bytes = read(adb_read_fd, &result, sizeof(result))) == MAX_ADB_READ) {
+			while ((bytes = read(adb_read_fd, &result, sizeof(result))) > 0) {
 				if (firstDataPacket) {
 					struct AdbBackupControlType data_block;
 


### PR DESCRIPTION
This will allow the gzip compression header to be
written properly to the adb stream.

Thanks to nkk71 for finding the issue.
Change-Id: I3d88c5f575ca3fac904d8279f1f246994be2b02f